### PR TITLE
[debian] Rename debian package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,23 @@
-# BlockSettle - `ArmoryDB` Headless Runtime
+# BlockSettleDB - `BitoinArmory` Headless Runtime
 
-This is a fork of [ArmoryDB](https://github.com/goatpig/BitcoinArmory) that produces
-a headless runtime of `ArmoryDB`. The wallet and trading platfrom from [blocksettle.com](http://blocksettle.com/) fully supports this version of ArmoryDB, and provides all the required UI tools to interact with the backend.
+This is a fork of [BitcoinArmory](https://github.com/goatpig/BitcoinArmory) that produces
+a headless runtime of `BlocksettleDB`. The wallet and trading platfrom from [blocksettle.com](http://blocksettle.com/) fully supports this version of BlocksettleDB, and provides all the required UI tools to interact with the backend.
 
-## Install ArmoryDB.
+## Install BlocksettleDB.
 BlockSettle provides binary distribution of the runtime for few platforms, including Ubuntu, Windows, and MacOS.
 
 ### Ubuntu 
 To install the binary release on Ubuntu, 
 ```bash
-sudo add-apt-repository ppa:blocksettle/armorydb
+sudo add-apt-repository ppa:blocksettle/blocksettledb
 sudo apt-get update
 
-sudo apt-get install armorydb
+sudo apt-get install blocksettledb
 ```
-For more information and other available packages please visit our Launchpad page [launchpad.net/BlockSettle] (https://launchpad.net/~blocksettle/+archive/ubuntu/armorydb )
+For more information and other available packages please visit our Launchpad page [launchpad.net/BlockSettle] (https://launchpad.net/~blocksettle/+archive/ubuntu/blocksettledb )
 
-## Running `ArmoryDB`
-Before you can run Armorydb you have to make sure you have successfully setup bitcoin core on your system and it is fully synced. You can download the bitcoin core for your distribution from [bitcoin.org](https://bitcoin.org/en/download). You can select between "testnet" and "mainnet" depending on what you want to do. Optionally if you whish to save your bitcoin core settings you can use [Bitcoin Core Config Generator](https://jlopp.github.io/bitcoin-core-config-generator/) to easily create a fully functional bitcon.conf file online. Please note that the following parameters are important. 
+## Running `BlocksettleDB`
+Before you can run BlocksettleDB you have to make sure you have successfully setup bitcoin core on your system and it is fully synced. You can download the bitcoin core for your distribution from [bitcoin.org](https://bitcoin.org/en/download). You can select between "testnet" and "mainnet" depending on what you want to do. Optionally if you whish to save your bitcoin core settings you can use [Bitcoin Core Config Generator](https://jlopp.github.io/bitcoin-core-config-generator/) to easily create a fully functional bitcon.conf file online. Please note that the following parameters are important. 
 
 * enable server=1 or --server
 * disablewallert=0 
@@ -30,31 +30,31 @@ and example command would look like this.
 #if you saved all your settings to bitcoin.conf
 ./bitcoind --conf=/home/<your_path>/.bitcon/bitcon.conf 
 ```
-### ArmoryDB connection design
+### BlocksettleDB connection design
 
-ArmoryDB *must* run alongside the Bitcoin Core node. This is because ArmoryDB
-does a memory map on the blockchain files. This can only be done if ArmoryDB
+BlocksettleDB *must* run alongside the Bitcoin Core node. This is because BlocksettleDB
+does a memory map on the blockchain files. This can only be done if BlocksettleDB
 and the node are running on the same OS and, ideally, on the same storage
 device. The IP address of the Core node is hardcoded (localhost) and can't be
-changed without recompiling Armory (and changing the design at your own risk!).
+changed without recompiling BlocksettleDB (and changing the design at your own risk!).
 Only the node's port can be changed via the `satoshirpc-port` parameter. This
 design may change in the future.
 
-It is possible for Armory and other clients to talk to ArmoryDB remotely.
-Possibilities for reaching ArmoryDB include placing ArmoryDB behind an HTTP
-daemon or logging into the ArmoryDB machine remotely via VPN. Talking to
-ArmoryDB is done via JSON-encoded packets, as seen in the `armoryd` project.
+It is possible for BlocksettleDB and other clients to talk to BlocksettleDB remotely.
+Possibilities for reaching BlocksettleDB include placing BlocksettleDB behind an HTTP
+daemon or logging into the BlocksettleDB machine remotely via VPN. Talking to
+BlocksettleDB is done via JSON-encoded packets, as seen in the `armoryd` project.
 
-`ArmoryDB` works by reading the blockchain downloaded by Bitcoin Core and
-finding any transactions relevant to the wallets loaded into Armory. This means
+`BlocksettleDB` works by reading the blockchain downloaded by Bitcoin Core and
+finding any transactions relevant to the wallets loaded into BlocksettleDB. This means
 that the entire blockchain must be rescanned whenever a new wallet or lockbox
 is loaded. Once a wallet/lockbox has been loaded and the blockchain fully
-scanned for that wallet, ArmoryDB will keep an eye on the blockchain. Any
+scanned for that wallet, BlocksettleDB will keep an eye on the blockchain. Any
 transactions relevant to the addresses controlled by wallets/lockboxes will be
-resolved. In addition, as Armory builds its own mempool by talking to the Core
-node, any relevant zero-confirmation transactions will be resolved by ArmoryDB.
+resolved. In addition, as BlocksettleDB builds its own mempool by talking to the Core
+node, any relevant zero-confirmation transactions will be resolved by BlocksettleDB.
 
-### Start ArmoryDB headless Server.
+### Start BlocksettleDB headless Server.
 By default it will try to connect to your running bitcoin core RPC API, and also read data from your bitcoin core block files on your disk. If your bitcoin core configuration differs from the default and you have setup data directories on non standard locations, then you will also have to tell armorydb using command-line parameters or using a config file where it can locate the block files downloaded by bitcoin core. The supported parameters are listed at [Armorydb FAQ](https://btcarmory.com/docs/faq)
 
 
@@ -72,19 +72,19 @@ The database types are as follows:
   instantly resolved into its relevant data. The database will be at least
   ~100GB large. Default database type.
 
-Note that the flags may be added to the Armory root data directory in an
-ArmoryDB config file (`armorydb.conf`). The file will set the parameters every
-time ArmoryDB is started. Command line flags, including flags used by Armory,
-will override config values. (Changing Armory's default values will require
+Note that the flags may be added to the BlocksettleDB root data directory in an
+BlocksettleDB config file (`armorydb.conf`). The file will set the parameters every
+time BlocksettleDB is started. Command line flags, including flags used by BlocksettleDB,
+will override config values. (Changing BlocksettleDB's default values will require
 recompilation.) An example file that mirrors the default parameters used by
-Armory can be seen below.
+BlocksettleDB can be seen below.
 
 ```
 db-type="DB_SUPER"
 cookie=1
 satoshi-datadir="/home/snakamoto/.bitcoin/blocks""
-datadir="/home/snakamoto/Armory/"
-dbdir="/home/snakamoto/Armory/databases"
+datadir="/home/snakamoto/blocksettledb/"
+dbdir="/home/snakamoto/blocksettledb/databases"
 ```
 
 ## Build instructions
@@ -113,26 +113,26 @@ On Windows dependencies are handled automatically with vcpkg.Addtinally a proper
 * Windows 10 SDK at least one version (in our case 10.0.18363.xx)( these numbers can disappear so just for reference if it's a recent enough installation.)
 * Also double check MSVC build tools are installed. 
 
-### ArmoryDB build instructions for Ubuntu/MacOS
+### BlocksettleDB build instructions for Ubuntu/MacOS
 
-The following steps will build ArmoryDB:
+The following steps will build BlocksettleDB:
 
 ```
-cd /path/to/ArmoryDB
+cd /path/to/BlocksettleDB
 mkdir build
 cd build
 cmake ..
 make -j`nproc`
 ```
-### ArmoryDB build instructions for Windows 10.
+### BlocksettleDB build instructions for Windows 10.
 
 - Clone and Setup ArmodyDB and Build Environment.
 
 ```bash
 %comspec% /k "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat"
 cd c:\projects\
-git clone https://github.com/BlockSettle/ArmoryDB.git
-cd ArmoryDB
+git clone https://github.com/BlockSettle/BlocksettleDB.git
+cd BlocksettleDB
 mkdir build
 cd build
 cmake .. -DVCPKG_TARGET_TRIPLET=x64-windows -DCMAKE_CXX_FLAGS="/MP /EHa" -DCMAKE_C_FLAGS="/MP"
@@ -141,12 +141,12 @@ msbuild -m -p:BuildInParallel=true -p:Configuration=Release ALL_BUILD.vcxproj
 
 `vcpkg` will be installed automatically.
 
-Overall, Armory tries to use static linking. There will still be a few dependencies, as
+Overall, BlocksettleDB tries to use static linking. There will still be a few dependencies, as
 seen by `ldd` (Ubuntu) or `otool -L` (macOS). This should be fine. If there are
 any issues, they can be addressed as they are encountered.
 
 On Windows on the other hand, there will be `.dll` files built along with the
-binary, and they must be in the same directory as the `ArmoryDB` binary if it
+binary, and they must be in the same directory as the `BlocksettleDB` binary if it
 is to be distributed or moved. Or somewhere in the `PATH` environment variable.
 
 TODO: use static vcpkg triplet for windows
@@ -195,17 +195,17 @@ The following changes have been made compared to the upstream version of Armory:
 
 - The Armory-specific "public mode" of BIP 150 is the default (i.e., verify the
   server but not the client). Users who wish to do two-way verification will
-  need to invoke `ArmoryDB` with the `--fullbip150` flag, which restores
-  ArmoryDB to the default BIP 150 behavior for the upstream ArmoryDB.
+  need to invoke `BlocksettleDB` with the `--fullbip150` flag, which restores
+  BlocksettleDB to the default BIP 150 behavior for the upstream BlocksettleDB.
 
 - The default config type is changed from `FULL` node to `SUPERNODE`.
 
 - `FULL` node support currently does **NOT** work.
 
 - The python and GUI support is not built by default unless all the
-  dependencies are available. This fork is concerned only with `ArmoryDB`.
+  dependencies are available. This fork is concerned only with `BlocksettleDB`.
 
-- The datadir is `$HOME/.armorydb` by default.
+- The datadir is `$HOME/.blocksettledb` by default.
 
 ## Merging Upstream
 

--- a/cppForSwig/BlockDataManagerConfig.cpp
+++ b/cppForSwig/BlockDataManagerConfig.cpp
@@ -46,51 +46,51 @@ SOCKET_SERVICE BlockDataManagerConfig::service_ = SERVICE_WEBSOCKET;
 ARMORY_OPERATION_MODE BlockDataManagerConfig::operationMode_ = OPERATION_REGULAR;
 
 ////////////////////////////////////////////////////////////////////////////////
-// ArmoryDB repo: Default directories switched - Armory -> ArmoryDB -> BSArmoryDB
+// ArmoryDB repo: Default directories switched - Armory -> ArmoryDB -> blocksettledb
 const string BlockDataManagerConfig::dbDirExtention_ = "/databases";
 #if defined(_WIN32)
 const string BlockDataManagerConfig::defaultDataDir_ = 
-   "~/BSArmoryDB";
+   "~/blocksettledb";
 const string BlockDataManagerConfig::defaultBlkFileLocation_ = 
    "~/Bitcoin/blocks";
 
 const string BlockDataManagerConfig::defaultTestnetDataDir_ = 
-   "~/BSArmoryDB/testnet3";
+   "~/blocksettledb/testnet3";
 const string BlockDataManagerConfig::defaultTestnetBlkFileLocation_ = 
    "~/Bitcoin/testnet3/blocks";
 
 const string BlockDataManagerConfig::defaultRegtestDataDir_ = 
-   "~/BSArmoryDB/regtest";
+   "~/blocksettledb/regtest";
 const string BlockDataManagerConfig::defaultRegtestBlkFileLocation_ = 
    "~/Bitcoin/regtest/blocks";
 #elif defined(__APPLE__)
 const string BlockDataManagerConfig::defaultDataDir_ = 
-   "~/Library/Application Support/BSArmoryDB";
+   "~/Library/Application Support/blocksettledb";
 const string BlockDataManagerConfig::defaultBlkFileLocation_ = 
    "~/Library/Application Support/Bitcoin/blocks";
 
 const string BlockDataManagerConfig::defaultTestnetDataDir_ = 
-   "~/Library/Application Support/BSArmoryDB/testnet3";
+   "~/Library/Application Support/blocksettledb/testnet3";
 const string BlockDataManagerConfig::defaultTestnetBlkFileLocation_ =   
    "~/Library/Application Support/Bitcoin/testnet3/blocks";
 
 const string BlockDataManagerConfig::defaultRegtestDataDir_ = 
-   "~/Library/Application Support/BSArmoryDB/regtest";
+   "~/Library/Application Support/blocksettledb/regtest";
 const string BlockDataManagerConfig::defaultRegtestBlkFileLocation_ = 
    "~/Library/Application Support/Bitcoin/regtest/blocks";
 #else
 const string BlockDataManagerConfig::defaultDataDir_ = 
-   "~/.bsarmorydb";
+   "~/.blocksettledb";
 const string BlockDataManagerConfig::defaultBlkFileLocation_ = 
    "~/.bitcoin/blocks";
 
 const string BlockDataManagerConfig::defaultTestnetDataDir_ = 
-   "~/.bsarmorydb/testnet3";
+   "~/.blocksettledb/testnet3";
 const string BlockDataManagerConfig::defaultTestnetBlkFileLocation_ = 
    "~/.bitcoin/testnet3/blocks";
 
 const string BlockDataManagerConfig::defaultRegtestDataDir_ = 
-   "~/.bsarmorydb/regtest";
+   "~/.blocksettledb/regtest";
 const string BlockDataManagerConfig::defaultRegtestBlkFileLocation_ = 
    "~/.bitcoin/regtest/blocks";
 #endif

--- a/cppForSwig/CMakeLists.txt
+++ b/cppForSwig/CMakeLists.txt
@@ -340,21 +340,21 @@ if(WITH_GUI)
     )
 endif()
 
-add_executable(bsarmorydb
+add_executable(blocksettledb
     main.cpp
 )
 
-set_target_properties(bsarmorydb
+set_target_properties(blocksettledb
     PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}
 )
 
-target_link_libraries(bsarmorydb
+target_link_libraries(blocksettledb
     ArmoryCLI
 )
 
 include(GNUInstallDirs)
 
-install(TARGETS bsarmorydb DESTINATION ${CMAKE_INSTALL_BINDIR})
+install(TARGETS blocksettledb DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 add_executable(BIP150KeyManager
     KeyManager.cpp

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,29 +1,5 @@
-armorydb (0.97~git20190812.6.571b9a41) unstable; urgency=medium
+blocksettledb (0.8.9) unstable; urgency=medium
 
-  * New upstream release
+  * New Release 
 
  -- BlockSettle AB <hello@blocksettle.com>  Tue, 13 Aug 2019 18:42:42 +0300
-
-armorydb (0.97~git20190712.5.cbbcf017) unstable; urgency=medium
-
-  * New upstream release
-
- -- BlockSettle AB <hello@blocksettle.com>  Fri, 12 Jul 2019 08:40:53 +0000
-
-armorydb (0.97~git20190307.1.b9a6268-1) unstable; urgency=medium
-
-  * New upstream release
-
- -- BlockSettle AB <hello@blocksettle.com>  Thu, 07 Mar 2019 12:58:29 +0000
-
-armorydb (0.97~git20190228.41a7b36-1) unstable; urgency=medium
-
-  * New upstream release
-
- -- BlockSettle AB <hello@blocksettle.com>  Thu, 28 Feb 2019 13:03:05 +0000
-
-armorydb (0.97~git20190213.970f9b0-1) unstable; urgency=medium
-
-  * Initial release.
-
- -- BlockSettle AB <hello@blocksettle.com>  Tue, 12 Feb 2019 10:49:32 +0000

--- a/debian/control
+++ b/debian/control
@@ -1,4 +1,4 @@
-Source: armorydb
+Source: blocksettledb
 Section: net
 Priority: optional
 Maintainer: BlockSettle AB <hello@blocksettle.com>
@@ -6,7 +6,7 @@ Build-Depends: debhelper (>= 9), cmake, pkg-config, libprotobuf-dev, protobuf-co
 Standards-Version: 4.1.2
 Homepage: http://blocksettle.com
 
-Package: armorydb
+Package: blocksettledb
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}
 Description: Server part of Armory


### PR DESCRIPTION
rename debian package to blocksettledb

[build] Rename BSAmoryDB to blocksettledb

rename all paths and binary names to blocksettledb

[readme] Update readme

Remove reference to ArmoryDB and replace it with BlocksettleDB